### PR TITLE
Fixed bug in address-book deletion

### DIFF
--- a/srx.go
+++ b/srx.go
@@ -462,7 +462,7 @@ func (j *Junos) ConvertAddressBook() []string {
 			}
 		}
 
-		removeConfig := fmt.Sprintf("delete security zone security-zones %s address-book\n", z.Name)
+		removeConfig := fmt.Sprintf("delete security zones security-zones %s address-book\n", z.Name)
 		globalAddressBook = append(globalAddressBook, removeConfig)
 	}
 

--- a/srx.go
+++ b/srx.go
@@ -462,7 +462,7 @@ func (j *Junos) ConvertAddressBook() []string {
 			}
 		}
 
-		removeConfig := fmt.Sprintf("delete security zones security-zones %s address-book\n", z.Name)
+		removeConfig := fmt.Sprintf("delete security zones security-zone %s address-book\n", z.Name)
 		globalAddressBook = append(globalAddressBook, removeConfig)
 	}
 


### PR DESCRIPTION
SRX Address-book deletion was failing due to a typo in the delete command
