### PR TITLE
Add optional logger to NewSession

### DIFF
--- a/junos.go
+++ b/junos.go
@@ -158,9 +158,18 @@ type File struct {
 
 // NewSession establishes a new connection to a Junos device that we will use
 // to run our commands against. NewSession also gathers software information
-// about the device.
-func NewSession(host, user, password string) (*Junos, error) {
+// about the device.  logger is optional for additonal NETCONF logging
+// logger is any logger that implements the netconf.Logger interface (ex: logrus)
+func NewSession(host, user, password string, logger ...interface{}) (*Junos, error) {
 	rex := regexp.MustCompile(`^.*\[(.*)\]`)
+
+	if logger != nil {
+		l, ok := logger[0].(netconf.Logger)
+		if ok {
+			netconf.SetLog(l)
+		}
+	}
+
 	s, err := netconf.DialSSH(host, netconf.SSHConfigPassword(user, password))
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
This PR adds an optional logger to `NewSession`,  this allows enablement of the go-netconf logging capabilities, particularly debug.

Any log package that implements the netconf.Logger interface can be used to 
allow additional logging of NETCONF/RPC messages

_example (using logrus):_
```go
log := logrus.New()
log.Level = logrus.DebugLevel
s, err := j.NewSession("1.2.3.4", "toomany", "secrets", log)
```

Making `logger` variadic, allows this be added and not break existing code bases using `NewSession`