### PR TITLE
Remove extraneous Println in Unlock()

### DIFF
--- a/junos.go
+++ b/junos.go
@@ -662,7 +662,6 @@ func (j *Junos) RollbackConfig(option interface{}) error {
 // Unlock unlocks the candidate configuration.
 func (j *Junos) Unlock() error {
 	reply, err := j.Session.Exec(netconf.RawRPC(rpcUnlock))
-	fmt.Println(reply)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
`fmt.Println(reply)` in `Unlock()` prints raw RPC to console in any kind of interactive usage.  

This PR removes this print statement 