### PR TITLE
A fix for 'staticnat' view on clustered/ha nodes (E.g. SRX)

### DIFF
--- a/views.go
+++ b/views.go
@@ -444,7 +444,6 @@ func (j *Junos) Views(view string) (*Views, error) {
 			}
 
 			for _, c := range srxstaticnats.Entries {
-				if strings.Contains(c.Name)
 				staticnats.Entries = append(staticnats.Entries, c)
 			}
 

--- a/views.go
+++ b/views.go
@@ -256,6 +256,12 @@ type StaticNats struct {
 	Entries []StaticNatEntry `xml:"static-nat-rule-entry"`
 }
 
+// srxStaticNats contains static NATs configured across a clustered-mode SRX
+type srxStaticNats struct {
+	Count   int              `xml:"multi-routing-engine-item>static-nat-rule-information>total-static-nat-rules>total-rules"`
+	Entries []StaticNatEntry `xml:"multi-routing-engine-item>static-nat-rule-information"`
+}
+
 // StaticNatEntry holds each individual static NAT entry.
 type StaticNatEntry struct {
 	Name       string `xml:"rule-name"`
@@ -313,7 +319,7 @@ func validatePlatform(j *Junos, v string) error {
 
 // Views gathers information on the device given the "view" specified. These views can be interrated/looped over to view the
 // data (i.e. ARP table entries, interface details/statistics, routing tables, etc.). Supported views are:
-// arp, route, interface, vlan, ethernetswitch, inventory.
+// arp, route, interface, vlan, ethernetswitch, inventory, staticnat.
 func (j *Junos) Views(view string) (*Views, error) {
 	var results Views
 
@@ -431,11 +437,25 @@ func (j *Junos) Views(view string) (*Views, error) {
 		var staticnats StaticNats
 		formatted := strings.Replace(reply.Data, "\n", "", -1)
 
-		if err := xml.Unmarshal([]byte(formatted), &staticnats); err != nil {
-			return nil, err
-		}
+		if strings.Contains(reply.Data, "multi-routing-engine-results") {
+			var srxstaticnats srxStaticNats
 
-		results.StaticNat = staticnats
+			if err := xml.Unmarshal([]byte(formatted), &srxstaticnats); err != nil {
+				return nil, err
+			}
+
+			for _, c := range srxstaticnats.Entries {
+				staticnats.Entries = append(staticnats.Entries, c)
+			}
+
+			results.StaticNat = staticnats
+		} else {
+			if err := xml.Unmarshal([]byte(formatted), &staticnats); err != nil {
+				return nil, err
+			}
+
+			results.StaticNat = staticnats
+		}
 	}
 
 	return &results, nil

--- a/views.go
+++ b/views.go
@@ -258,8 +258,7 @@ type StaticNats struct {
 
 // srxStaticNats contains static NATs configured across a clustered-mode SRX
 type srxStaticNats struct {
-	Count   int              `xml:"multi-routing-engine-item>static-nat-rule-information>total-static-nat-rules>total-rules"`
-	Entries []StaticNatEntry `xml:"multi-routing-engine-item>static-nat-rule-information"`
+	Entries []StaticNatEntry `xml:"multi-routing-engine-item>static-nat-rule-information>static-nat-rule-entry"`
 }
 
 // StaticNatEntry holds each individual static NAT entry.
@@ -445,6 +444,7 @@ func (j *Junos) Views(view string) (*Views, error) {
 			}
 
 			for _, c := range srxstaticnats.Entries {
+				if strings.Contains(c.Name)
 				staticnats.Entries = append(staticnats.Entries, c)
 			}
 


### PR DESCRIPTION
Hello,

I noticed that the 'staticnat' view worked against a standalone Juniper SRX box, however when I got around to trying the view against a clustered chassis, the response comes back as null.

After some poking around I determined this can be fixed by creating a new struct (srxStaticNats) and then populating that if multiple route engines are detected. The logic was copied from how the 'inventory' view is setup in the same file.

Please feel free to review and kick back if you have anything you'd like to change or add to this PR, happy to do so.

Cheers,
Buck