### PR TITLE
Removed netconf.Logger refs

### DIFF
--- a/junos.go
+++ b/junos.go
@@ -157,15 +157,8 @@ type versionPackageInfo struct {
 // to run our commands against. NewSession also gathers software information
 // about the device. Logger is optional for additonal NETCONF logging
 // logger is any logger that implements the netconf.Logger interface (ex: logrus)
-func NewSession(host, user, password string, logger ...interface{}) (*Junos, error) {
+func NewSession(host, user, password string) (*Junos, error) {
 	rex := regexp.MustCompile(`^.*\[(.*)\]`)
-
-	if logger != nil {
-		l, ok := logger[0].(netconf.Logger)
-		if ok {
-			netconf.SetLog(l)
-		}
-	}
 
 	s, err := netconf.DialSSH(host, netconf.SSHConfigPassword(user, password))
 	if err != nil {

--- a/junos.go
+++ b/junos.go
@@ -155,8 +155,7 @@ type versionPackageInfo struct {
 
 // NewSession establishes a new connection to a Junos device that we will use
 // to run our commands against. NewSession also gathers software information
-// about the device. Logger is optional for additonal NETCONF logging
-// logger is any logger that implements the netconf.Logger interface (ex: logrus)
+// about the device.
 func NewSession(host, user, password string) (*Junos, error) {
 	rex := regexp.MustCompile(`^.*\[(.*)\]`)
 


### PR DESCRIPTION
Upstream package file `netconf/log.go` was removed entirely in commit https://github.com/Juniper/go-netconf/commit/3e51c371774c49664923cdf92d2fbc16dce44a29. This simple change is meant to similarly remove references to this interface as it prevents fetching the package via `go get`.

This was only found as an optional arg for the `NewSession` function in `junos.go`. Of course, feel free to reject this merge if you have different thoughts and ideas for handling this :)

