### PR TITLE
Include additional property for tunnel interfaces

### DIFF
--- a/views.go
+++ b/views.go
@@ -97,6 +97,7 @@ type LogicalInterface struct {
 	OutputPackets      int    `xml:"traffic-statistics>output-packets"`
 	AddressFamily      string `xml:"address-family>address-family-name"`
 	AggregatedEthernet string `xml:"address-family>ae-bundle-name,omitempty"`
+	LinkAddress        string `xml:"link-address,omitempty"`
 }
 
 // Vlans contains all of the VLAN information on the device.


### PR DESCRIPTION
This is required to read the source and destination of a IPIP tunnel interface.