### PR TITLE
Remove debugging Println call from View()

### DIFF
--- a/views.go
+++ b/views.go
@@ -455,7 +455,6 @@ func (j *Junos) View(view string, option ...string) (*Views, error) {
 		}
 	}
 
-	fmt.Println(len(option))
 	if view == "interface" && len(option) > 0 {
 		rpcIntName := fmt.Sprintf("<get-interface-information><interface-name>%s</interface-name></get-interface-information>", option[0])
 		reply, err = j.Session.Exec(netconf.RawMethod(rpcIntName))


### PR DESCRIPTION
Looks like some debug code was left in View().  Please merge this so we don't get the unnecessary output.