### PR TITLE
Add CIDR field to LogicalInterface

### DIFF
--- a/views.go
+++ b/views.go
@@ -81,6 +81,7 @@ type PhysicalInterface struct {
 type LogicalInterface struct {
 	Name               string `xml:"name"`
 	MTU                string `xml:"address-family>mtu"`
+	CIDR               string `xml:"address-family>interface-address>ifa-destination"`
 	IPAddress          string `xml:"address-family>interface-address>ifa-local"`
 	LocalIndex         int    `xml:"local-index"`
 	SNMPIndex          int    `xml:"snmp-index"`


### PR DESCRIPTION
Without this change, the user is unable to determine the mask applied to the
interface.  Here we include a CIDR field that maps to the ifa-destination, which
includes the full prefix assigned to the LogicalInterface.