### PR TITLE
Include new PhysicalInterface field InterfaceType

### DIFF
--- a/views.go
+++ b/views.go
@@ -63,6 +63,7 @@ type PhysicalInterface struct {
 	LocalIndex              int                `xml:"local-index"`
 	SNMPIndex               int                `xml:"snmp-index"`
 	LinkLevelType           string             `xml:"link-level-type"`
+	InterfaceType           string             `xml:"if-type"`
 	MTU                     string             `xml:"mtu"`
 	LinkMode                string             `xml:"link-mode"`
 	Speed                   string             `xml:"speed"`


### PR DESCRIPTION
Without this change, there is no facility to know if a loopback interface is of
type Loopback.  Here we include a new field for InterfaceType.